### PR TITLE
feat: Support Karpenter nodes and nodepoolInfo grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Nodepool related information
   - Node list
   - Topology info (Region & Zone)
   - Instance type
-  - Nodepool provider (supported: EKS/AKS/GKE)
+  - Nodepool provider (supported: EKS/AKS/GKE/Karpenter)
 <p align="center"><img src="/assets/nodegizmo-nodepool.png" alt="Nodegizmo node "/></p>
 
 ##### nodegizmo node exec nodeName

--- a/pkg/constants.go
+++ b/pkg/constants.go
@@ -2,9 +2,10 @@ package pkg
 
 // required constants used across the CLI commands (mostly well-known labels, annotations etc.,)
 const (
-	AwsNodepoolLabel = "eks.amazonaws.com/nodegroup"
-	GkeNodepoolLabel = "cloud.google.com/gke-nodepool"
-	AksNodepoolLabel = "kubernetes.azure.com/agentpool"
+	AwsNodepoolLabel  = "eks.amazonaws.com/nodegroup"
+	GkeNodepoolLabel  = "cloud.google.com/gke-nodepool"
+	AksNodepoolLabel  = "kubernetes.azure.com/agentpool"
+	KarpenterNodepool = "karpenter.sh/provisioner-name"
 
 	NodeInstanceTypeLabel = "node.kubernetes.io/instance-type"
 	TopologyRegionLabel   = "topology.kubernetes.io/region"

--- a/pkg/outputs/table.go
+++ b/pkg/outputs/table.go
@@ -10,7 +10,12 @@ import (
 func TableOutput(headers []string, outputData [][]string) {
 	table := tablewriter.NewWriter(os.Stdout)
 
-	// misc configs for the table-writer
+	// enables autoMerge only for nodepool infos
+	if headers[0] == "NODEPOOL" {
+		table.SetAutoMergeCells(true)
+	}
+
+	// default configs for the table-writer
 	table.SetRowLine(false)
 	table.SetBorder(false)
 	table.SetAutoWrapText(false)
@@ -23,7 +28,6 @@ func TableOutput(headers []string, outputData [][]string) {
 	table.SetColumnSeparator("")
 	table.SetRowSeparator("")
 	table.SetTablePadding("\t")
-	table.SetNoWhiteSpace(true)
 
 	// set headers and add the outputData
 	table.SetHeader(headers)

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -35,7 +35,7 @@ type NodeCapacities struct {
 // GenericNodepoolInfo required node pool info which is used 'nodepool' command
 type GenericNodepoolInfo struct {
 	NodepoolID   string
-	Nodes        []string
+	Node         string
 	Provider     string
 	InstanceType string
 	Region       string


### PR DESCRIPTION
Fixes #23 

```
❯ go build -o nodegizmo && ./nodegizmo nodepool
  NODEPOOL                            PROVIDER   REGION     ZONE        INSTANCE-TYPE  NODES
  default                             Karpenter  us-east-1  us-east-1a  t3a.small      ip-10-0-0-93.ec2.internal
                                                                                       ip-10-0-10-158.ec2.internal
                                                                                       ip-10-0-11-132.ec2.internal
                                                                        t3.small       ip-10-0-14-108.ec2.internal
                                                            us-east-1b  t3a.small      ip-10-0-19-158.ec2.internal
                                                                                       ip-10-0-22-210.ec2.internal
                                                                                       ip-10-0-24-21.ec2.internal
                                                                                       ip-10-0-30-193.ec2.internal
                                                                                       ip-10-0-31-180.ec2.internal
                                                            us-east-1c  t3a.medium     ip-10-0-32-151.ec2.internal
                                                                                       ip-10-0-32-179.ec2.internal
                                                                        t3a.small      ip-10-0-33-207.ec2.internal
                                                                                       ip-10-0-37-144.ec2.internal
                                                                                       ip-10-0-37-55.ec2.internal
                                                                                       ip-10-0-38-99.ec2.internal
                                                            us-east-1a                 ip-10-0-4-128.ec2.internal
                                                                                       ip-10-0-4-53.ec2.internal
                                                            us-east-1c                 ip-10-0-40-105.ec2.internal
                                                                                       ip-10-0-40-11.ec2.internal
                                                                                       ip-10-0-41-98.ec2.internal
                                                                                       ip-10-0-42-88.ec2.internal
                                                                        t3a.medium     ip-10-0-46-105.ec2.internal
  generic-2023102107344574640000001e  EKS                   us-east-1b  t3.medium      ip-10-0-23-172.ec2.internal
                                                            us-east-1c                 ip-10-0-33-54.ec2.internal
                                                            us-east-1a                 ip-10-0-7-138.ec2.internal
```