### PR TITLE
feat: Support latest Karpenter and Openshift MP labels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Kavinraja-G/node-gizmo
 
-go 1.23.0
+go 1.24
 
 require (
 	github.com/docker/cli v24.0.7+incompatible

--- a/pkg/cmd/nodepool/nodepool.go
+++ b/pkg/cmd/nodepool/nodepool.go
@@ -74,6 +74,12 @@ func getNodepoolIDAndProvider(labels map[string]string) (string, string) {
 	if id, ok := labels[pkg.KarpenterNodepool]; ok {
 		return "Karpenter", id
 	}
+	if id, ok := labels[pkg.KarpenterNodepoolV1]; ok {
+		return "Karpenter", id
+	}
+	if id, ok := labels[pkg.OpenshiftMachinepool]; ok {
+		return "Openshift", id
+	}
 
 	return "Unknown", "Unknown"
 }

--- a/pkg/constants.go
+++ b/pkg/constants.go
@@ -2,10 +2,12 @@ package pkg
 
 // required constants used across the CLI commands (mostly well-known labels, annotations etc.,)
 const (
-	AwsNodepoolLabel  = "eks.amazonaws.com/nodegroup"
-	GkeNodepoolLabel  = "cloud.google.com/gke-nodepool"
-	AksNodepoolLabel  = "kubernetes.azure.com/agentpool"
-	KarpenterNodepool = "karpenter.sh/provisioner-name"
+	AwsNodepoolLabel     = "eks.amazonaws.com/nodegroup"
+	GkeNodepoolLabel     = "cloud.google.com/gke-nodepool"
+	AksNodepoolLabel     = "kubernetes.azure.com/agentpool"
+	KarpenterNodepool    = "karpenter.sh/provisioner-name"
+	KarpenterNodepoolV1  = "karpenter.sh/nodepool"
+	OpenshiftMachinepool = "hive.openshift.io/machine-pool"
 
 	NodeInstanceTypeLabel = "node.kubernetes.io/instance-type"
 	TopologyRegionLabel   = "topology.kubernetes.io/region"


### PR DESCRIPTION
- Bump go to 1.24
- Support Karpenter latest API and Openshift Machinepool labels